### PR TITLE
fixed bug in splay tree

### DIFF
--- a/src/algvis/splaytree/SplayAlg.java
+++ b/src/algvis/splaytree/SplayAlg.java
@@ -12,9 +12,11 @@ public class SplayAlg extends Algorithm {
 	public SplayAlg(Splay T, int x) {
 		super(T.M);
 		this.T = T;
-		T.v = s = new SplayNode(T, K = x);
-		s.bgColor(Colors.FIND);
-		setHeader("splay");
+		if (T.root != null) {
+			T.v = s = new SplayNode(T, K = x);
+			s.bgColor(Colors.FIND);
+			setHeader("splay");
+		}
 	}
 	
 	public BSTNode find(int K) {

--- a/src/algvis/splaytree/SplayInsert.java
+++ b/src/algvis/splaytree/SplayInsert.java
@@ -13,6 +13,7 @@ public class SplayInsert extends SplayAlg {
 	@Override
 	public void run() {
 		if (T.root == null) {
+			setHeader("insertion");
 			T.root = v;
 			v.goToRoot();
 			setText("newroot");


### PR DESCRIPTION
when inserting the first node, there were two nodes on the screen - one yellow and another grey, which stayed on the screen until second insertion
