### PR TITLE
Fibonacci heap improvements

### DIFF
--- a/src/algvis/ds/priorityqueues/fibonacciheap/FibHeapDecrKey.java
+++ b/src/algvis/ds/priorityqueues/fibonacciheap/FibHeapDecrKey.java
@@ -41,25 +41,21 @@ public class FibHeapDecrKey extends Algorithm {
         if (v.prec(H.min[i])) {
             H.min[i] = v;
         }
-        if (v.parent.prec(v)) {
+        if (v.isRoot() || v.parent.prec(v)) {
             return;
         }
-        BinHeapNode w = v.parent;
-        // if (w == null) return;
-        while (w != null) {
+        do {
+            BinHeapNode p = v.parent;
             v.unlink();
             v.unmarkCut();
             H.root[i].linkLeft(v);
             H.reposition();
             pause();
-            if (w.cut) {
-                v = w;
-                w = v.parent;
-            } else {
-                w.markCut();
-                H.reposition();
-                break;
-            }
+            v = p;
+        } while (v.cut);
+        if (!v.isRoot()) {
+            v.markCut();
+            H.reposition();
         }
     }
 }

--- a/src/algvis/ds/priorityqueues/fibonacciheap/FibHeapDecrKey.java
+++ b/src/algvis/ds/priorityqueues/fibonacciheap/FibHeapDecrKey.java
@@ -38,15 +38,15 @@ public class FibHeapDecrKey extends Algorithm {
         setHeader(H.minHeap ? "decreasekey" : "increasekey");
         final int i = H.active;
         v.decrKey(delta, H.minHeap);
+        if (v.prec(H.min[i])) {
+            H.min[i] = v;
+        }
         BinHeapNode w = v.parent;
         // if (w == null) return;
         while (w != null) {
             v.unlink();
             v.unmarkCut();
             H.root[i].linkLeft(v);
-            if (v.prec(H.min[i])) {
-                H.min[i] = v;
-            }
             H.reposition();
             pause();
             if (w.cut) {

--- a/src/algvis/ds/priorityqueues/fibonacciheap/FibHeapDecrKey.java
+++ b/src/algvis/ds/priorityqueues/fibonacciheap/FibHeapDecrKey.java
@@ -41,6 +41,9 @@ public class FibHeapDecrKey extends Algorithm {
         if (v.prec(H.min[i])) {
             H.min[i] = v;
         }
+        if (v.parent.prec(v)) {
+            return;
+        }
         BinHeapNode w = v.parent;
         // if (w == null) return;
         while (w != null) {

--- a/src/algvis/ds/priorityqueues/lazybinomialheap/LazyBinHeapDelete.java
+++ b/src/algvis/ds/priorityqueues/lazybinomialheap/LazyBinHeapDelete.java
@@ -70,6 +70,7 @@ public class LazyBinHeapDelete extends Algorithm {
                 w.left = tr;
                 w.right = tl;
                 w = tr;
+                w.unmarkCut(); // root nodes in Fibonacci heap are never marked
             } while (w != v);
             w = w.right;
             // link


### PR DESCRIPTION
Fixed Fibonacci heap behavior:
- nothing should be done if the heap property is satisfied after DecrKey
- root nodes should never be marked for cut

And some small refactoring of the whole FibHeapDecrKey